### PR TITLE
Remove namespaces for public types

### DIFF
--- a/src/NServiceBus.ClaimCheck.Tests/APIApprovals.cs
+++ b/src/NServiceBus.ClaimCheck.Tests/APIApprovals.cs
@@ -11,7 +11,7 @@ public class APIApprovals
     [Test]
     public void ApproveClaimCheck()
     {
-        var publicApi = typeof(ClaimCheckFeature).Assembly.GeneratePublicApi(new ApiGeneratorOptions
+        var publicApi = typeof(ClaimCheck).Assembly.GeneratePublicApi(new ApiGeneratorOptions
         {
             ExcludeAttributes = ["System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute"]
         });

--- a/src/NServiceBus.ClaimCheck.Tests/ApprovalFiles/APIApprovals.ApproveClaimCheck.approved.txt
+++ b/src/NServiceBus.ClaimCheck.Tests/ApprovalFiles/APIApprovals.ApproveClaimCheck.approved.txt
@@ -28,7 +28,26 @@ namespace NServiceBus.ClaimCheck
     {
         public const string ClaimCheckConfigContentType = "NServiceBus.DataBusConfig.ContentType";
     }
-    public class ClaimCheckProperty<T> : NServiceBus.ClaimCheck.IClaimCheckProperty
+    public static class ConventionsBuilderExtensions
+    {
+        public static NServiceBus.ConventionsBuilder DefiningClaimCheckPropertiesAs(this NServiceBus.ConventionsBuilder builder, System.Func<System.Reflection.PropertyInfo, bool> definesClaimCheckProperty) { }
+    }
+    public interface IClaimCheck
+    {
+        System.Threading.Tasks.Task<System.IO.Stream> Get(string key, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<string> Put(System.IO.Stream stream, System.TimeSpan timeToBeReceived, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Start(System.Threading.CancellationToken cancellationToken = default);
+    }
+    public interface IClaimCheckSerializer
+    {
+        string ContentType { get; }
+        object Deserialize(System.Type propertyType, System.IO.Stream stream);
+        void Serialize(object claimCheckProperty, System.IO.Stream stream);
+    }
+}
+namespace NServiceBus
+{
+    public class ClaimCheckProperty<T> : NServiceBus.IClaimCheckProperty
         where T :  class
     {
         public ClaimCheckProperty() { }
@@ -45,22 +64,12 @@ namespace NServiceBus.ClaimCheck
     }
     public static class ConfigureFileShareClaimCheck
     {
-        public static NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.ClaimCheck.FileShareClaimCheck> BasePath(this NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.ClaimCheck.FileShareClaimCheck> config, string basePath) { }
-    }
-    public static class ConventionsBuilderExtensions
-    {
-        public static NServiceBus.ConventionsBuilder DefiningClaimCheckPropertiesAs(this NServiceBus.ConventionsBuilder builder, System.Func<System.Reflection.PropertyInfo, bool> definesClaimCheckProperty) { }
+        public static NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.FileShareClaimCheck> BasePath(this NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.FileShareClaimCheck> config, string basePath) { }
     }
     public class FileShareClaimCheck : NServiceBus.ClaimCheck.ClaimCheckDefinition
     {
         public FileShareClaimCheck() { }
         protected override System.Type ProvidedByFeature() { }
-    }
-    public interface IClaimCheck
-    {
-        System.Threading.Tasks.Task<System.IO.Stream> Get(string key, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<string> Put(System.IO.Stream stream, System.TimeSpan timeToBeReceived, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task Start(System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IClaimCheckProperty
     {
@@ -70,12 +79,6 @@ namespace NServiceBus.ClaimCheck
         object GetValue();
         void SetValue(object value);
     }
-    public interface IClaimCheckSerializer
-    {
-        string ContentType { get; }
-        object Deserialize(System.Type propertyType, System.IO.Stream stream);
-        void Serialize(object claimCheckProperty, System.IO.Stream stream);
-    }
     public class SystemJsonClaimCheckSerializer : NServiceBus.ClaimCheck.IClaimCheckSerializer
     {
         public SystemJsonClaimCheckSerializer() { }
@@ -83,16 +86,6 @@ namespace NServiceBus.ClaimCheck
         public object Deserialize(System.Type propertyType, System.IO.Stream stream) { }
         public void Serialize(object claimCheckProperty, System.IO.Stream stream) { }
     }
-}
-namespace NServiceBus.Features
-{
-    public class ClaimCheckFeature : NServiceBus.Features.Feature
-    {
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
-    }
-}
-namespace NServiceBus
-{
     public static class UseClaimCheckExtensions
     {
         public static NServiceBus.ClaimCheck.ClaimCheckExtensions UseClaimCheck(this NServiceBus.EndpointConfiguration config, System.Func<System.IServiceProvider, NServiceBus.ClaimCheck.IClaimCheck> claimCheckFactory, NServiceBus.ClaimCheck.IClaimCheckSerializer claimCheckSerializer) { }
@@ -101,5 +94,12 @@ namespace NServiceBus
         public static NServiceBus.ClaimCheck.ClaimCheckExtensions<TClaimCheckDefinition> UseClaimCheck<TClaimCheckDefinition, TClaimCheckSerializer>(this NServiceBus.EndpointConfiguration config)
             where TClaimCheckDefinition : NServiceBus.ClaimCheck.ClaimCheckDefinition, new ()
             where TClaimCheckSerializer : NServiceBus.ClaimCheck.IClaimCheckSerializer, new () { }
+    }
+}
+namespace NServiceBus.Features
+{
+    public class ClaimCheck : NServiceBus.Features.Feature
+    {
+        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
 }

--- a/src/NServiceBus.ClaimCheck.Tests/DataBusConfigurationTests.cs
+++ b/src/NServiceBus.ClaimCheck.Tests/DataBusConfigurationTests.cs
@@ -20,7 +20,7 @@ public class DataBusConfigurationTests
             .AddDeserializer(new FakeDataBusSerializer("content-type-1"))
             .AddDeserializer(new FakeDataBusSerializer("content-type-2"));
 
-        Assert.That(endpointConfiguration.GetSettings().Get<List<IClaimCheckSerializer>>(NServiceBus.Features.ClaimCheckFeature.AdditionalClaimCheckDeserializersKey).Count, Is.EqualTo(2));
+        Assert.That(endpointConfiguration.GetSettings().Get<List<IClaimCheckSerializer>>(Features.ClaimCheck.AdditionalClaimCheckDeserializersKey).Count, Is.EqualTo(2));
     }
 
     [Test]

--- a/src/NServiceBus.ClaimCheck/ClaimCheck.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheck.cs
@@ -5,16 +5,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using ClaimCheck;
+using NServiceBus.ClaimCheck;
 using Microsoft.Extensions.DependencyInjection;
 using Settings;
 
 /// <summary>
 /// Used to configure the claim check implementation.
 /// </summary>
-public class ClaimCheckFeature : Feature
+public class ClaimCheck : Feature
 {
-    internal ClaimCheckFeature()
+    internal ClaimCheck()
     {
         Defaults(s => s.EnableFeatureByDefault(GetSelectedFeatureForClaimCheck(s)));
     }

--- a/src/NServiceBus.ClaimCheck/ClaimCheckDeserializer.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheckDeserializer.cs
@@ -1,9 +1,10 @@
-﻿namespace NServiceBus.ClaimCheck;
+﻿namespace NServiceBus;
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using NServiceBus.Logging;
+using ClaimCheck;
 
 class ClaimCheckDeserializer
 {

--- a/src/NServiceBus.ClaimCheck/ClaimCheckExtensions.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheckExtensions.cs
@@ -51,14 +51,14 @@ public class ClaimCheckExtensions : ExposeSettings
     {
         ArgumentNullException.ThrowIfNull(serializer);
 
-        var deserializers = this.GetSettings().Get<List<IClaimCheckSerializer>>(Features.ClaimCheckFeature.AdditionalClaimCheckDeserializersKey);
+        var deserializers = this.GetSettings().Get<List<IClaimCheckSerializer>>(Features.ClaimCheck.AdditionalClaimCheckDeserializersKey);
 
         if (deserializers.Any(d => d.ContentType == serializer.ContentType))
         {
             throw new ArgumentException($"Deserializer for content type '{serializer.ContentType}' is already registered.");
         }
 
-        var mainSerializer = this.GetSettings().Get<IClaimCheckSerializer>(Features.ClaimCheckFeature.ClaimCheckSerializerKey);
+        var mainSerializer = this.GetSettings().Get<IClaimCheckSerializer>(Features.ClaimCheck.ClaimCheckSerializerKey);
 
         if (mainSerializer.ContentType == serializer.ContentType)
         {

--- a/src/NServiceBus.ClaimCheck/ClaimCheckFileBased.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheckFileBased.cs
@@ -8,7 +8,7 @@ class ClaimCheckFileBased : Feature
 {
     public ClaimCheckFileBased()
     {
-        DependsOn<ClaimCheckFeature>();
+        DependsOn<ClaimCheck>();
     }
 
     /// <summary>

--- a/src/NServiceBus.ClaimCheck/ClaimCheckProperty.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheckProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.ClaimCheck;
+﻿namespace NServiceBus;
 
 using System;
 using System.Text.Json.Serialization;

--- a/src/NServiceBus.ClaimCheck/ClaimCheckPropertyInfo.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheckPropertyInfo.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.ClaimCheck;
+namespace NServiceBus;
 
 using System;
 

--- a/src/NServiceBus.ClaimCheck/ClaimCheckReceiveBehavior.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheckReceiveBehavior.cs
@@ -1,8 +1,9 @@
-﻿namespace NServiceBus.ClaimCheck;
+﻿namespace NServiceBus;
 
 using System;
 using System.Threading.Tasks;
 using System.Transactions;
+using ClaimCheck;
 using Pipeline;
 
 class ClaimCheckReceiveBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>

--- a/src/NServiceBus.ClaimCheck/ClaimCheckSendBehavior.cs
+++ b/src/NServiceBus.ClaimCheck/ClaimCheckSendBehavior.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.ClaimCheck;
+﻿namespace NServiceBus;
 
 using System;
 using System.IO;
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Extensions.DependencyInjection;
 using Pipeline;
+using ClaimCheck;
 using Transport;
 
 class ClaimCheckSendBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>

--- a/src/NServiceBus.ClaimCheck/ConfigureFileShareClaimCheck.cs
+++ b/src/NServiceBus.ClaimCheck/ConfigureFileShareClaimCheck.cs
@@ -1,7 +1,8 @@
-namespace NServiceBus.ClaimCheck;
+namespace NServiceBus;
 
 using System;
 using Configuration.AdvancedExtensibility;
+using ClaimCheck;
 
 /// <summary>
 /// Contains extension methods to <see cref="EndpointConfiguration" /> for the file share implementation of the claim check pattern.

--- a/src/NServiceBus.ClaimCheck/ConventionsBuilderExtensions.cs
+++ b/src/NServiceBus.ClaimCheck/ConventionsBuilderExtensions.cs
@@ -16,12 +16,12 @@ public static class ConventionsBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(definesClaimCheckProperty);
 
-        var claimCheckConventions = builder.GetSettings().GetOrDefault<ClaimCheckConventions>(Features.ClaimCheckFeature.ClaimCheckConventionsKey);
+        var claimCheckConventions = builder.GetSettings().GetOrDefault<ClaimCheckConventions>(Features.ClaimCheck.ClaimCheckConventionsKey);
 
         if (claimCheckConventions == null)
         {
             claimCheckConventions = new ClaimCheckConventions();
-            builder.GetSettings().Set(Features.ClaimCheckFeature.ClaimCheckConventionsKey, claimCheckConventions);
+            builder.GetSettings().Set(Features.ClaimCheck.ClaimCheckConventionsKey, claimCheckConventions);
         }
 
         claimCheckConventions.IsClaimCheckPropertyAction = definesClaimCheckProperty;

--- a/src/NServiceBus.ClaimCheck/CustomClaimCheck.cs
+++ b/src/NServiceBus.ClaimCheck/CustomClaimCheck.cs
@@ -1,7 +1,8 @@
-﻿namespace NServiceBus.ClaimCheck;
+﻿namespace NServiceBus;
 
 using System;
 using Features;
+using ClaimCheck;
 
 class CustomClaimCheck : ClaimCheckDefinition
 {

--- a/src/NServiceBus.ClaimCheck/CustomIClaimCheck.cs
+++ b/src/NServiceBus.ClaimCheck/CustomIClaimCheck.cs
@@ -7,12 +7,12 @@ class CustomIClaimCheck : Feature
 {
     public CustomIClaimCheck()
     {
-        DependsOn<ClaimCheckFeature>();
+        DependsOn<ClaimCheck>();
     }
 
     protected override void Setup(FeatureConfigurationContext context)
     {
-        var customClaimCheckDefinition = context.Settings.Get<ClaimCheckDefinition>(ClaimCheckFeature.SelectedClaimCheckKey) as CustomClaimCheck;
+        var customClaimCheckDefinition = context.Settings.Get<ClaimCheckDefinition>(ClaimCheck.SelectedClaimCheckKey) as CustomClaimCheck;
 
         if (customClaimCheckDefinition is not null)
         {

--- a/src/NServiceBus.ClaimCheck/FileShareClaimCheck.cs
+++ b/src/NServiceBus.ClaimCheck/FileShareClaimCheck.cs
@@ -1,7 +1,8 @@
-namespace NServiceBus.ClaimCheck;
+namespace NServiceBus;
 
 using System;
 using Features;
+using ClaimCheck;
 
 /// <summary>
 /// Base class for implementations of the claim check pattern definitions.

--- a/src/NServiceBus.ClaimCheck/FileShareClaimCheckImplementation.cs
+++ b/src/NServiceBus.ClaimCheck/FileShareClaimCheckImplementation.cs
@@ -1,10 +1,11 @@
-namespace NServiceBus.ClaimCheck;
+namespace NServiceBus;
 
 using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Logging;
+using ClaimCheck;
 
 class FileShareClaimCheckImplementation : IClaimCheck
 {

--- a/src/NServiceBus.ClaimCheck/IClaimCheckProperty.cs
+++ b/src/NServiceBus.ClaimCheck/IClaimCheckProperty.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.ClaimCheck;
+﻿namespace NServiceBus;
 
 using System;
 

--- a/src/NServiceBus.ClaimCheck/SystemJsonClaimCheckSerializer.cs
+++ b/src/NServiceBus.ClaimCheck/SystemJsonClaimCheckSerializer.cs
@@ -1,8 +1,9 @@
-﻿namespace NServiceBus.ClaimCheck;
+﻿namespace NServiceBus;
 
 using System;
 using System.IO;
 using System.Text.Json;
+using NServiceBus.ClaimCheck;
 
 /// <summary>
 /// Claim Check serialization using the <see cref="JsonSerializer"/> serializer.

--- a/src/NServiceBus.ClaimCheck/UseClaimCheckExtensions.cs
+++ b/src/NServiceBus.ClaimCheck/UseClaimCheckExtensions.cs
@@ -62,15 +62,15 @@ public static class UseClaimCheckExtensions
 
     static void EnableClaimCheck(EndpointConfiguration config, ClaimCheckDefinition selectedClaimCheck, IClaimCheckSerializer claimCheckSerializer)
     {
-        config.GetSettings().Set(Features.ClaimCheckFeature.SelectedClaimCheckKey, selectedClaimCheck);
-        config.GetSettings().Set(Features.ClaimCheckFeature.ClaimCheckSerializerKey, claimCheckSerializer);
-        config.GetSettings().Set(Features.ClaimCheckFeature.AdditionalClaimCheckDeserializersKey, new List<IClaimCheckSerializer>());
+        config.GetSettings().Set(Features.ClaimCheck.SelectedClaimCheckKey, selectedClaimCheck);
+        config.GetSettings().Set(Features.ClaimCheck.ClaimCheckSerializerKey, claimCheckSerializer);
+        config.GetSettings().Set(Features.ClaimCheck.AdditionalClaimCheckDeserializersKey, new List<IClaimCheckSerializer>());
 
-        if (!config.GetSettings().HasSetting(Features.ClaimCheckFeature.ClaimCheckConventionsKey))
+        if (!config.GetSettings().HasSetting(Features.ClaimCheck.ClaimCheckConventionsKey))
         {
-            config.GetSettings().Set(Features.ClaimCheckFeature.ClaimCheckConventionsKey, new ClaimCheckConventions());
+            config.GetSettings().Set(Features.ClaimCheck.ClaimCheckConventionsKey, new ClaimCheckConventions());
         }
 
-        config.EnableFeature<Features.ClaimCheckFeature>();
+        config.EnableFeature<Features.ClaimCheck>();
     }
 }


### PR DESCRIPTION
Makes the namespaces match the ones in the deprecated NServiceBus.DataBus folder